### PR TITLE
Fix comparisons to numbers and among units of different types

### DIFF
--- a/src/SIUnits.jl
+++ b/src/SIUnits.jl
@@ -224,8 +224,20 @@ module SIUnits
     real(x::SIQuantity) = typeof(x)(real(x.val))
     imag(x::SIQuantity) = typeof(x)(imag(x.val))
 
-    function isless{T,S,mS,kgS,sS,AS,KS,molS,cdS,mT,kgT,sT,AT,KT,molT,cdT}(
-        x::SIQuantity{T,mT,kgT,sT,AT,KT,molT,cdT},y::SIQuantity{S,mS,kgS,sS,AS,KS,molS,cdS}) 
+    function isless{T}(x::SIQuantity{T,0,0,0,0,0,0,0}, y::SIQuantity{T,0,0,0,0,0,0,0})
+        return isless(x.val,y.val)
+    end
+    function isless{T,S}(x::SIQuantity{T,0,0,0,0,0,0,0}, y::SIQuantity{S,0,0,0,0,0,0,0})
+        return isless(x.val,y.val)
+    end
+    function isless{T}(x::SIQuantity{T,0,0,0,0,0,0,0}, y::Number)
+        return isless(x.val,y)
+    end
+    function isless{T}(x::Number, y::SIQuantity{T,0,0,0,0,0,0,0})
+        return isless(x,y.val)
+    end
+    function isless{T,S,mT,kgT,sT,AT,KT,molT,cdT}(
+        x::SIQuantity{T,mT,kgT,sT,AT,KT,molT,cdT},y::SIQuantity{S,mT,kgT,sT,AT,KT,molT,cdT}) 
         return isless(x.val,y.val)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,3 +94,9 @@ bu=[2N 3N 4N]
 a = 1m
 b = 2mm
 @test (pi*a^2)/b == (pi/2)*(m^2/mm)
+
+# Comparisons with numbers and different units
+a = SIUnits.UnitQuantity{Float64}(3.0)
+@test a < 4
+@test 2.8 < a
+@test_throws_compat MethodError 1m < 2kg


### PR DESCRIPTION
Prior to this,

```
julia> 1m<2kg
true
```

Also, since currently type inference yields

```
r = 1.0m./[1m,2m]
julia> typeof(r[1])
SIQuantity{Float64,0,0,0,0,0,0,0} (constructor with 1 method)
```

(even when inside a function), it's important to have comparisons between plain numbers and objects of type `SIQuantity{Float64,0,0,0,0,0,0,0}`.
