### PR TITLE
Fix range typing and a typo in range indexing

### DIFF
--- a/src/SIUnits.jl
+++ b/src/SIUnits.jl
@@ -11,7 +11,7 @@ module SIUnits
     immutable SIUnit{m,kg,s,A,K,mol,cd} <: Number
     end 
 
-    abstract SIRanges{T<:Real,m,kg,s,A,K,mol,cd} <: Ranges{T}
+    abstract SIRanges{T<:Real,m,kg,s,A,K,mol,cd} <: Ranges{SIQuantity{T,m,kg,s,A,K,mol,cd}}
 
     immutable SIRange{T<:Real,m,kg,s,A,K,mol,cd} <: SIRanges{T,m,kg,s,A,K,mol,cd}
         val::Range{T}
@@ -36,7 +36,7 @@ module SIUnits
         end
     end
     show(io::IO, r::SIRange1) = print(io, first(r),':',last(r))
-    getindex(r::SIRanges,i::Integer) = (quantity(r)(getindex(x.val,i)))
+    getindex(r::SIRanges,i::Integer) = (quantity(r)(getindex(r.val,i)))
     function next(r::SIRanges, i) 
         v, j = next(r.val,i)
         to_q(quantity(r),v), j

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,6 +68,7 @@ r1 = 1Hz:5Hz
 @test length(r1) == 5
 
 @test collect(1Hz:5Hz) == collect(1:5)Hz # Tests the iteration protocol
+@test r1[1] == 1Hz # Test indexing
 
 # Others
 


### PR DESCRIPTION
Arrays of SIQuantities are subtypes of AbstractArray{SIQuantity{T<:Real,...}}. But ranges were just subtypes of AbstractArray{T<:Real}.  This patch makes SI ranges and arrays dispatch more similarly.

Before:

```
julia> f{T<:SIUnits.SIQuantity}(::AbstractArray{T}) = "Unitful!"
f (generic function with 1 method)

julia> f([1s,2s,3s])
"Unitful!"

julia> f(1s:3s)
ERROR: `f` has no method matching f(::SIRange1{Int64,0,0,1,0,0,0,0})
```

After:

```
julia> f{T<:SIUnits.SIQuantity}(::AbstractArray{T}) = "Unitful!"
f (generic function with 1 method)

julia> f(1s:3s)
"Unitful!"
```

This also fixes a small typo in range indexing.
