### PR TITLE
Make SIRange concrete for all Range types

### DIFF
--- a/src/SIUnits.jl
+++ b/src/SIUnits.jl
@@ -13,6 +13,11 @@ module SIUnits
 
     abstract SIRanges{T,m,kg,s,A,K,mol,cd} <: Ranges{SIQuantity{T,m,kg,s,A,K,mol,cd}}
 
+    if !isdefined(Base, :UnitRange)
+        const Range = Ranges # Deprecations introduced early in the 0.3 cycle
+        const UnitRange = Range1
+    end
+
     immutable SIRange{R<:Range,T<:Real,m,kg,s,A,K,mol,cd} <: SIRanges{T,m,kg,s,A,K,mol,cd}
         val::R
     end


### PR DESCRIPTION
This simplifies the definition of SIRange, allowing it to wrap all Range types as first class values. This improves inference on the range functions, for example:

Before

```
julia> @code_typed(length(1s:0.1s:2s))
1-element Array{Any,1}:
 :($(Expr(:lambda, {:r}, {{},{{:r,SIRange{Float64,0,0,1,0,0,0,0},0}},{}}, :(begin  # /Users/mbauman/.julia/v0.3/SIUnits/src/SIUnits.jl, line 44:
        return length(top(getfield)(r::SIRange{Float64,0,0,1,0,0,0,0},:val)::Range{Float64})
    end))))
```

After

```
julia> @code_typed(length(1s:0.1s:2s))
1-element Array{Any,1}:
 :($(Expr(:lambda, {:r}, {{},{{:r,SIRange{FloatRange{Float64},Float64,0,0,1,0,0,0,0},0}},{}}, :(begin  # /Users/mbauman/.julia/v0.3/SIUnits/src/SIUnits.jl, line 40:
        return top(box)(Int64,top(fpsiround)(Int64,top(getfield)(top(getfield)(r::SIRange{FloatRange{Float64},Float64,0,0,1,0,0,0,0},:val)::FloatRange{Float64},:len)::Float64))::Int64
    end::Int64))))
```

This removes the definition of `SIRange1` as it is no longer needed.  As it was neither tested or exported, I have not done anything to deprecate it.  I have kept the abstract `SIRanges`, even though it is no longer necessary or exported, to keep the interface stable.
