### PR TITLE
Multiplicative and addititive identities

### DIFF
--- a/src/SIUnits.jl
+++ b/src/SIUnits.jl
@@ -27,7 +27,9 @@ module SIUnits
     import Base: length, getindex, next, float64, float, int, show, start, step, last, done, first, eltype, one, zero
 
     one(x::SIQuantity) = SIQuantity(one(x.val))
+    one{T,m,kg,s,A,K,mol,cd}(::Type{SIQuantity{T,m,kg,s,A,K,mol,cd}}) = SIQuantity(one(T))
     zero(x::SIQuantity) = zero(x.val) * unit(x)
+    zero{T,m,kg,s,A,K,mol,cd}(::Type{SIQuantity{T,m,kg,s,A,K,mol,cd}}) = zero(T) * SIUnit{m,kg,s,A,K,mol,cd}()
 
     # This is all nessecary because SIQuanity{T<:Real} !<: Real
     show(io::IO, x::SIRanges) = (show(io, x.val); show(io,unit(x)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,9 @@ end
 @test_throws_compat ErrorException 1//2V - 1V
 @test_throws_compat ErrorException 1V + 2s + 2kg
 @test 1V + zero(1V) == 1V
+@test 1V + zero(typeof(1V)) == 1V
 @test 1V * one(1V) == 1V
+@test 1V * one(typeof(1V)) == 1V
 
 OneNewton = 1*(kg*m/s^2)
 @test OneNewton*(1s)^2 == 1kg*m


### PR DESCRIPTION
This introduces `one(x)` and `zero(x)` for `x` of type `SIQuantity`.

The behavior is designed so that the two methods are multiplicative
and additive identities, respectively, i.e.

``` julia
x * one(x) == x
x + zero(x) == x
```

This is intended to fix JuliaLang/julia#18 and at least help mitigating JuliaLang/LinearAlgebra.jl#128.
