### PR TITLE
RFC: one(x::SIQuantity{T}) returns T

### DIFF
--- a/src/SIUnits.jl
+++ b/src/SIUnits.jl
@@ -27,8 +27,8 @@ module SIUnits
 
     import Base: length, getindex, next, float64, float, int, show, start, step, last, done, first, eltype, one, zero
 
-    one(x::SIQuantity) = SIQuantity(one(x.val))
-    one{T,m,kg,s,A,K,mol,cd}(::Type{SIQuantity{T,m,kg,s,A,K,mol,cd}}) = SIQuantity(one(T))
+    one(x::SIQuantity) = one(x.val)
+    one{T,m,kg,s,A,K,mol,cd}(::Type{SIQuantity{T,m,kg,s,A,K,mol,cd}}) = one(T)
     zero(x::SIQuantity) = zero(x.val) * unit(x)
     zero{T,m,kg,s,A,K,mol,cd}(::Type{SIQuantity{T,m,kg,s,A,K,mol,cd}}) = zero(T) * SIUnit{m,kg,s,A,K,mol,cd}()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,10 @@ end
 @test 1V + zero(typeof(1V)) == 1V
 @test 1V * one(1V) == 1V
 @test 1V * one(typeof(1V)) == 1V
+@test 3V / 3V == one(3)
+@test 3.V / 3.V === one(3.)
+@test isa(3.V / 3.V, typeof(one(3.)))
+@test isa(one(3.V), typeof(one(3.)))
 
 OneNewton = 1*(kg*m/s^2)
 @test OneNewton*(1s)^2 == 1kg*m


### PR DESCRIPTION
In some discussion in #18 that happened after #30 was merged, it was suggested that `one(x::SIQuantity)` should return a basic number type (i.e. the result of `one(x.val)`) rather than an `SIQuantity`. This PR changes that, and adds a few tests.

I'm not 100% certain this behavior is better than the previous, but at least this way it's easy to compare them, and this PR can serve as the basis for a concious decision.
