### PR TITLE
Promotion of identical SIQuantities shouldn't be concrete

### DIFF
--- a/src/SIUnits.jl
+++ b/src/SIUnits.jl
@@ -69,7 +69,7 @@ module SIUnits
         end
     end
 
-    import Base: +, -, *, /, //, ^, promote_rule, convert, show, ==, mod
+    import Base: +, -, *, /, //, ^, promote_rule, promote_type, convert, show, ==, mod
 
     export quantity, @quantity
 
@@ -103,6 +103,11 @@ module SIUnits
 
     # One unspecified, units, one concrete (unspecified occurs as the promotion result from the rules above)
     promote_rule{T,S,m,kg,s,A,K,mol,cd}(x::Type{SIQuantity{T}},y::Type{SIQuantity{S,m,kg,s,A,K,mol,cd}}) = SIQuantity{promote_type(T,S)}
+
+    # Unlike most other types, the promotion of two identitical SIQuantities is
+    # not that type itself. As such, the promote_type behavior itself must be
+    # overridden. C.f. https://github.com/Keno/SIUnits.jl/issues/27
+    promote_type{T,m,kg,s,A,K,mol,cd}(::Type{SIQuantity{T,m,kg,s,A,K,mol,cd}}, ::Type{SIQuantity{T,m,kg,s,A,K,mol,cd}}) = SIQuantity{T}
 
     convert{T,m,kg,s,A,K,mol,cd}(::Type{SIQuantity{T}},x::SIUnit{m,kg,s,A,K,mol,cd}) = SIQuantity{T,m,kg,s,A,K,mol,cd}(one(T))
     convert{T}(::Type{SIQuantity{T}},x::T) = UnitQuantity{T}(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,3 +109,14 @@ a = SIUnits.UnitQuantity{Float64}(3.0)
 @test a < 4
 @test 2.8 < a
 @test_throws_compat MethodError 1m < 2kg
+
+# Issue #27
+@test ([1s]/(1s))[1] == 1
+@test ([1s]/(1.0s))[1] == 1
+@test ([1.0s]/(1s))[1] == 1
+@test ([1.0s]/(1.0s))[1] == 1
+
+@test ([1s]*(1s))[1] == 1s*s
+@test ([1s]*(1.0s))[1] == 1s*s
+@test ([1.0s]*(1s))[1] == 1s*s
+@test ([1.0s]*(1.0s))[1] == 1s*s


### PR DESCRIPTION
The default fallback for `promote_type` in [Base](https://github.com/JuliaLang/julia/blob/3ddbaa1c03dd2fe0829c4c84f9b526d3d866c22f/base/promotion.jl#L101) assumes that the promotion of two identical types is precisely that type itself.  Unfortunately, this is not true for SIQuantities, as they may be getting divided or multiplied and so we cannot infer the resulting type.  This is particularly important within array operations, where division of identical types previously resulted in the wrong type and multiplication threw a conversion error (since this was used in the preallocation of the resulting array).

Fixes #27.
