### PR TITLE
Change UnitTuple to work on 32&64-bit platforms

### DIFF
--- a/src/SIUnits.jl
+++ b/src/SIUnits.jl
@@ -22,7 +22,7 @@ module SIUnits
         val::R
     end
 
-    typealias UnitTuple NTuple{7,Int64}
+    typealias UnitTuple NTuple{7,Int}
 
     unit{T,m,kg,s,A,K,mol,cd}(x::SIRanges{T,m,kg,s,A,K,mol,cd}) = SIUnit{m,kg,s,A,K,mol,cd}()
     quantity{T,m,kg,s,A,K,mol,cd}(x::SIRanges{T,m,kg,s,A,K,mol,cd}) = SIQuantity{T,m,kg,s,A,K,mol,cd}


### PR DESCRIPTION
This will at least allow `SIUnits` to load and pass tests on a 32-bit platform.

**N.B.:  There are still overflow problems for all platforms with the very small and very large prefixes.**
