### PR TITLE
Specialize indexing SIRanges by a range

### DIFF
--- a/src/SIUnits.jl
+++ b/src/SIUnits.jl
@@ -45,6 +45,7 @@ module SIUnits
     end
     show{T<:UnitRange}(io::IO, r::SIRange{T}) = print(io, first(r),':',last(r))
     getindex(r::SIRanges,i::Integer) = (quantity(r)(getindex(r.val,i)))
+    getindex{T<:SIRanges}(r::T,i::Range) = T(getindex(r.val,i))
     function next(r::SIRanges, i) 
         v, j = next(r.val,i)
         to_q(quantity(r),v), j

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,6 +78,8 @@ r1 = 1Hz:5Hz
 @test collect(1Hz:5Hz) == collect(1:5)Hz # Tests the iteration protocol
 @test r1[1] == 1Hz # Test indexing
 
+@test r1[2:4] == 2Hz:4Hz # Indexing ranges by ranges should be SIRanges
+
 # Ranges: Ensure forwarded methods are working appropriately
 @test eltype(r1) == typeof(1Hz)
 @test first(r1) == step(r1) == 1Hz


### PR DESCRIPTION
Use the range-specific methods instead of the AbstractArray fallbacks
