### PR TITLE
Define ==(::SIUnit,::SIUnit)

### DIFF
--- a/src/SIUnits.jl
+++ b/src/SIUnits.jl
@@ -224,6 +224,7 @@ module SIUnits
     ==(x::SIQuantity,y::SIQuantity) = (tup(x) == tup(y)) && (x.val == y.val)
     =={T}(x::SIQuantity{T},y::SIUnit) = (tup(x) == tup(y)) && (x.val == one(T))
     =={T}(x::SIUnit,y::SIQuantity{T}) = (tup(x) == tup(y)) && (one(T) == y.val)
+    ==(x::SIUnit,y::SIUnit) = tup(x) == tup(y)
 
     import Base: sqrt, abs, colon, isless, isfinite, isreal, real, imag, isnan
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,3 +133,6 @@ a = SIUnits.UnitQuantity{Float64}(3.0)
 @test ([1s]*(1.0s))[1] == 1s*s
 @test ([1.0s]*(1s))[1] == 1s*s
 @test ([1.0s]*(1.0s))[1] == 1s*s
+
+# Issue #49
+@test m != kg != s != A != K != mol != cd


### PR DESCRIPTION
This fixes #49 

The problem was that `SIUnit` inheriting `==` from `Number`, which assumed a promotion rule would exist.