### PR TITLE
show unit symbols for common units

### DIFF
--- a/src/SIUnits.jl
+++ b/src/SIUnits.jl
@@ -376,6 +376,25 @@ module SIUnits
         tup(x)[idx+1:end] == ntuple(7-idx, (i)->0) ? "" : " "
     end
     function show{m,kg,s,A,K,mol,cd}(io::IO,x::SIUnit{m,kg,s,A,K,mol,cd})
+        units = [
+          (Joule, "J"),
+          (Coulomb, "C"),
+          (Volt, "V"),
+          (Farad, "F"),
+          (Newton, "N"),
+          (Ohm, "Ω"),
+          (Hertz, "Hz"),
+          (Siemens, "S"),
+          (Watt, "W"),
+          (Pascal, "Pa")
+        ]
+        for (unit, symbol) = units
+          if unit == x
+            print(io, symbol)
+            return
+          end
+        end
+
         kg  != 0 && print(io, "kg",  (kg  == 1 ? spacing(1,x) : superscript(kg)))
         m   != 0 && print(io, "m",   (m   == 1 ? spacing(2,x) : superscript(m)))
         s   != 0 && print(io, "s",   (s   == 1 ? spacing(3,x) : superscript(s)))


### PR DESCRIPTION
I think it would be nice to see the unit symbol for common units, e.g. `N` for Newton instead of `kg m s⁻²`.

```julia
julia> using SIUnits

julia> using SIUnits.ShortUnits

julia> 10J
10 J

julia> 10J/s
10 W

julia> kg*m/s
kg m s⁻¹

julia> kg*m/s^2
N
```