### PR TITLE
Make SIUnits compatible with Gadfly

### DIFF
--- a/src/SIUnits.jl
+++ b/src/SIUnits.jl
@@ -264,10 +264,10 @@ module SIUnits
     function isless{T,S}(x::SIQuantity{T,0,0,0,0,0,0,0,0,0}, y::SIQuantity{S,0,0,0,0,0,0,0,0,0})
         return isless(x.val,y.val)
     end
-    function isless{T}(x::SIQuantity{T,0,0,0,0,0,0,0,0,0}, y::Number)
+    function isless{T}(x::SIQuantity{T,0,0,0,0,0,0,0,0,0}, y::Real)
         return isless(x.val,y)
     end
-    function isless{T}(x::Number, y::SIQuantity{T,0,0,0,0,0,0,0,0,0})
+    function isless{T}(x::Real, y::SIQuantity{T,0,0,0,0,0,0,0,0,0})
         return isless(x,y.val)
     end
     function isless{T,S,mT,kgT,sT,AT,KT,molT,cdT,radT,srT}(

--- a/src/SIUnits.jl
+++ b/src/SIUnits.jl
@@ -495,7 +495,7 @@ siquantity{B}(T,U::Type{NonSIUnit{B}}) = quantity(T,B())
 #convert{T,S,U}(::Type{SIQuantity{T}},x::NonSIQuantity{S,U}) = (siquantity(promote_type(T,S),U())(x.val))
 
 
-*{T<:NonSIUnit}(x,t::T) = NonSIQuantity{typeof(x),T}(x)
+*{T<:NonSIUnit}(x::Number,t::T) = NonSIQuantity{typeof(x),T}(x)
 
 baseunit{BaseUnit}(x::NonSIUnit{BaseUnit}) = BaseUnit()
 baseunit{T,Unit}(x::NonSIQuantity{T,Unit}) = baseunit(unit(x))


### PR DESCRIPTION
The point is to be able to plot quantities with units:

~~~Julia
using Gadfly
using SIUnits
using SIUnits.Shorthand
x = [1:16]m
plot(x=x, y=x.*x)
~~~

The example above issues warnings about function clashes with a `*` in Compose and `isless` in DualNumbers, both used by Gadfly.

This pull-request corrects both issues by declaring the functions with more specific types.

This pull-request would close #19.