### PR TITLE
change release to 0.4 and 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ os:
     - linux
     - osx
 julia:
-    - release
     - nightly
+    - 0.4
+    - 0.3
 notifications:
     email: false
 sudo: false


### PR DESCRIPTION
so 0.3 continues to get tested

(otherwise best to change require to 0.4 and bump minor package version at the next tag if you don't want to support 0.3 any more)