### PR TITLE
Add missing \mu abbreviations

### DIFF
--- a/src/shortunits.jl
+++ b/src/shortunits.jl
@@ -105,11 +105,13 @@ module ShortUnits
 
     # Support the other unicode codepoint for $\mu$
     # (namely the one we get on the REPL)
-    export μg, μm, μF, μA, μW
+    export μg, μm, μF, μA, μW, μs, μΩ
     const μg = µg
     const μm = µm
     const μF = µF
     const μA = µA
     const μW = µW
+    const μs = µs
+    const μΩ = µΩ
 
 end


### PR DESCRIPTION
Microsecond and microohm with `\mu` symbol were missing.