### PR TITLE
Allow printing of superscript decimal

### DIFF
--- a/src/SIUnits.jl
+++ b/src/SIUnits.jl
@@ -380,7 +380,8 @@ module SIUnits
         c   ==  '8' ? '\u2078' :
         c   ==  '9' ? '\u2079' :
         c   ==  '0' ? '\u2070' :
-        error("Unexpected Chatacter")
+        c   ==  '.' ? '\uff65' :
+        throw(DomainError("Unexpected character: $c"))
     end
 
     function spacing(idx::Int, x::SIUnit)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -172,3 +172,7 @@ for func in (sin,cos,tan,cot,sec,csc)
     @test func(1.23rad) == func(1.23)
     @test_approx_eq func(1.23deg) func(as(1.23deg,rad))
 end
+
+# Test printing and superscript()
+@test repr(SIUnits.SIQuantity{Float64,zeros(8)...,0.4}(1.0)) == "1.0 sr⁰･⁴"
+


### PR DESCRIPTION
Unicode has no superscript decimal character. Instead, it is faked using
U+FF65, HALFWIDTH KATAKANA MIDDLE DOT.

Also, improves error handling in `superscript()`
- Fix typo in error message
- `throw`s `DomainError` rather than a generic `error()`
- Error message now contains the invalid character in question

Example of usage:

    julia> SIUnits.SIQuantity{Float64,zeros(8)...,0.4}(1.0)
    1.0 sr⁰･⁴